### PR TITLE
Remove action_processing

### DIFF
--- a/pyblish_lite/control.py
+++ b/pyblish_lite/control.py
@@ -33,7 +33,6 @@ class Controller(QtCore.QObject):
     was_validated = QtCore.Signal()
     was_published = QtCore.Signal()
     was_acted = QtCore.Signal(dict)
-    action_processing = QtCore.Signal(object)
 
     # Emitted when processing has finished
     finished = QtCore.Signal()
@@ -88,7 +87,6 @@ class Controller(QtCore.QObject):
 
     def act(self, plugin, action):
         context = self.context
-        self.action_processing.emit(plugin)
 
         def on_next():
             result = pyblish.plugin.process(plugin, context, None, action.id)

--- a/pyblish_lite/delegate.py
+++ b/pyblish_lite/delegate.py
@@ -96,25 +96,23 @@ class Item(QtWidgets.QStyledItemDelegate):
 
         # Draw action icon
         if index.data(model.ActionIconVisible):
-            icon = icons["action"]
-            icon_rect = QtCore.QRectF(option.rect.adjusted(
-                label_rect.width() + 1, label_rect.height() / 3, 0, 0))
+            painter.save()
+
+            if index.data(model.ActionIdle):
+                color = colors["idle"]
+            elif index.data(model.ActionFailed):
+                color = colors["warning"]
+            else:
+                color = colors["ok"]
 
             painter.setFont(fonts["smallAwesome"])
-            state = index.data(model.ActionState)
-            color = colors["inactive"]
-            if state == "idle":
-                color = colors["idle"]
-            if state == "processing":
-                color = colors["active"]
-            if state == "succeeded":
-                color = colors["ok"]
-            if state == "failed":
-                color = colors["warning"]
-
             painter.setPen(QtGui.QPen(color))
 
-            painter.drawText(icon_rect, icon)
+            icon_rect = QtCore.QRectF(option.rect.adjusted(
+                label_rect.width() + 1, label_rect.height() / 3, 0, 0))
+            painter.drawText(icon_rect, icons["action"])
+
+            painter.restore()
 
         # Draw checkbox
         pen = QtGui.QPen(check_color, 1)


### PR DESCRIPTION
There are a few things I changed unneccessarily, such as your choice of model roles, but we should take another look at those as well. As you can see, most of what needs to happen happens with just two roles; isVisible and hasError. This is similar to how pyblish-qml does things.

Let's talk about it in https://github.com/pyblish/pyblish-lite/pull/55
